### PR TITLE
Ajustes na tela de configuração das colunas em tempo de design

### DIFF
--- a/GridSystem/src/GridSystem.ColumnDlg.fmx
+++ b/GridSystem/src/GridSystem.ColumnDlg.fmx
@@ -41,6 +41,7 @@ object GridSystemColumnDlg: TGridSystemColumnDlg
     Size.Height = 22.000000000000000000
     Size.PlatformDefault = False
     TabOrder = 4
+    OnChange = cboxScreenTypeChange
   end
   object sboxColumnCount: TSpinBox
     Touch.InteractiveGestures = [LongTap, DoubleTap]

--- a/GridSystem/src/GridSystem.ColumnDlg.pas
+++ b/GridSystem/src/GridSystem.ColumnDlg.pas
@@ -26,6 +26,7 @@ type
     procedure Button4Click(Sender: TObject);
     procedure FormDestroy(Sender: TObject);
     procedure FormShow(Sender: TObject);
+    procedure cboxScreenTypeChange(Sender: TObject);
   private
     FColumns: TGSColumnsDictionary;
     { Private declarations }
@@ -70,9 +71,11 @@ begin
     strgridColumns.Cells[1, FRow] := IntToStr(FColumns.Items[Key]);
     Inc(FRow);
   end;
+  cboxScreenTypeChange(nil);
 end;
 
 procedure TGridSystemColumnDlg.Button3Click(Sender: TObject);
+var Id:Integer;
 begin
   if not FColumns.ContainsKey(TScreenType(GetEnumValue(TypeInfo(TScreenType), cboxScreenType.Items[cboxScreenType.ItemIndex]))) then
   begin
@@ -80,7 +83,13 @@ begin
     strgridColumns.RowCount := strgridColumns.RowCount + 1;
     strgridColumns.Cells[0, strgridColumns.RowCount - 1] := cboxScreenType.Items[cboxScreenType.ItemIndex];
     strgridColumns.Cells[1, strgridColumns.RowCount - 1] := Round(sboxColumnCount.Value).ToString;
+  end
+  else
+  begin
+    FColumns.Items[TScreenType(GetEnumValue(TypeInfo(TScreenType), cboxScreenType.Items[cboxScreenType.ItemIndex]))] := Round(sboxColumnCount.Value);
+    BuildStrGrid;//TODO: change just specific row, for performance reasons  (or not...)
   end;
+  cboxScreenTypeChange(nil);
 end;
 
 procedure TGridSystemColumnDlg.Button4Click(Sender: TObject);
@@ -92,11 +101,23 @@ begin
   end;
 end;
 
+procedure TGridSystemColumnDlg.cboxScreenTypeChange(Sender: TObject);
+begin
+  Button3.Text := 'Add';
+  if FColumns.ContainsKey(TScreenType(GetEnumValue(TypeInfo(TScreenType), cboxScreenType.Items[cboxScreenType.ItemIndex]))) then
+  begin
+    Button3.Text := 'Alter';
+    sboxColumnCount.Value := FColumns.Items[TScreenType(GetEnumValue(TypeInfo(TScreenType), cboxScreenType.Items[cboxScreenType.ItemIndex]))];
+  end;
+
+end;
+
 procedure TGridSystemColumnDlg.FormCreate(Sender: TObject);
 begin
   FColumns := TGSColumnsDictionary.Create;
   AddScreenTypeToComboBox;
   SetColumnWidthToSpinBox;
+  cboxScreenTypeChange(nil);
 end;
 
 procedure TGridSystemColumnDlg.FormDestroy(Sender: TObject);


### PR DESCRIPTION
Carlos, achei muito show teu projeto, e quis ajudar um pouco, fiz uma pequena melhoria no editor em tempo de design, qualquer dúvida é só dar um toque!
Alteração:
Adicionado opção para alterar os valores de forma mais dinâmica. Agora não precisamos mais remover uma opção para então adicionar/alterar um número de colunas, e ao selecionar um tamanho de tela caso haja um número de colunas já configurado ele será carregado automaticamente.